### PR TITLE
fix memory issues

### DIFF
--- a/patches/src/rd.h.patch
+++ b/patches/src/rd.h.patch
@@ -1,32 +1,45 @@
 diff --git a/src/rd.h b/src/rd.h
-index fd6c307f..edff96f9 100644
+index fd6c307f..2b034c9c 100644
 --- a/src/rd.h
 +++ b/src/rd.h
-@@ -130,18 +130,27 @@
+@@ -130,21 +130,36 @@
   * will fail anyway, so no need to handle it handsomely.
   */
  static RD_INLINE RD_UNUSED void *rd_calloc(size_t num, size_t sz) {
-+      	// z/OS	returns	null when size is 0 which is different than linux.
-+      	if (sz == 0)
-+      	  sz=1;
++  	#ifdef __MVS__
++        // z/OS returns null when size is 0 which is different than linux.
++        if (sz == 0)
++          sz=1;
++        #endif
          void *p = calloc(num, sz);
-         rd_assert(p);
+-        rd_assert(p);
++  	rd_assert(p);
          return p;
  }
  
  static RD_INLINE RD_UNUSED void *rd_malloc(size_t sz) {
++        #ifdef __MVS__
 +        // z/OS returns null when size is 0 which is different than linux.
 +        if (sz == 0)
 +          sz=1;
++        #endif
          void *p = malloc(sz);
          rd_assert(p);
-         return p;
+-        return p;
++   	return p;
  }
  
  static RD_INLINE RD_UNUSED void *rd_realloc(void *ptr, size_t sz) {
-+      	// z/OS	returns	null when size is 0 which is different than linux.
-+      	if (sz == 0)
-+      	  sz=1;
++        #ifdef __MVS__
++	// z/OS returns null when size is 0 which is different than linux.
++        if (sz == 0)
++          sz=1;
++        #endif
          void *p = realloc(ptr, sz);
-         rd_assert(p);
-         return p;
+-        rd_assert(p);
+-        return p;
++	rd_assert(p);
++	return p;
+ }
+ 
+ static RD_INLINE RD_UNUSED void rd_free(void *ptr) {

--- a/patches/src/rd.h.patch
+++ b/patches/src/rd.h.patch
@@ -1,0 +1,32 @@
+diff --git a/src/rd.h b/src/rd.h
+index fd6c307f..edff96f9 100644
+--- a/src/rd.h
++++ b/src/rd.h
+@@ -130,18 +130,27 @@
+  * will fail anyway, so no need to handle it handsomely.
+  */
+ static RD_INLINE RD_UNUSED void *rd_calloc(size_t num, size_t sz) {
++      	// z/OS	returns	null when size is 0 which is different than linux.
++      	if (sz == 0)
++      	  sz=1;
+         void *p = calloc(num, sz);
+         rd_assert(p);
+         return p;
+ }
+ 
+ static RD_INLINE RD_UNUSED void *rd_malloc(size_t sz) {
++        // z/OS returns null when size is 0 which is different than linux.
++        if (sz == 0)
++          sz=1;
+         void *p = malloc(sz);
+         rd_assert(p);
+         return p;
+ }
+ 
+ static RD_INLINE RD_UNUSED void *rd_realloc(void *ptr, size_t sz) {
++      	// z/OS	returns	null when size is 0 which is different than linux.
++      	if (sz == 0)
++      	  sz=1;
+         void *p = realloc(ptr, sz);
+         rd_assert(p);
+         return p;

--- a/patches/src/rd.h.patch
+++ b/patches/src/rd.h.patch
@@ -1,8 +1,8 @@
 diff --git a/src/rd.h b/src/rd.h
-index fd6c307f..2b034c9c 100644
+index fd6c307f..8d9f38aa 100644
 --- a/src/rd.h
 +++ b/src/rd.h
-@@ -130,21 +130,36 @@
+@@ -130,18 +130,33 @@
   * will fail anyway, so no need to handle it handsomely.
   */
  static RD_INLINE RD_UNUSED void *rd_calloc(size_t num, size_t sz) {
@@ -12,8 +12,7 @@ index fd6c307f..2b034c9c 100644
 +          sz=1;
 +        #endif
          void *p = calloc(num, sz);
--        rd_assert(p);
-+  	rd_assert(p);
+         rd_assert(p);
          return p;
  }
  
@@ -25,8 +24,7 @@ index fd6c307f..2b034c9c 100644
 +        #endif
          void *p = malloc(sz);
          rd_assert(p);
--        return p;
-+   	return p;
+         return p;
  }
  
  static RD_INLINE RD_UNUSED void *rd_realloc(void *ptr, size_t sz) {
@@ -36,10 +34,5 @@ index fd6c307f..2b034c9c 100644
 +          sz=1;
 +        #endif
          void *p = realloc(ptr, sz);
--        rd_assert(p);
--        return p;
-+	rd_assert(p);
-+	return p;
- }
- 
- static RD_INLINE RD_UNUSED void rd_free(void *ptr) {
+         rd_assert(p);
+         return p;


### PR DESCRIPTION
Fix issues 
 1: 0x102B39A8 rd_calloc+0x68
 2: 0x10315484 rd_kafka_brokers_get_nodeids_async+0xc8
 3: 0x10508D44 rd_kafka_admin_worker+0x4e0
 4: 0x103E08D0 rd_kafka_op_handle+0x128
 5: 0x103B3438 rd_kafka_q_serve+0x4ac
 6: 0x102AE962 rd_kafka_thread_main+0xc3c
 7: 0x1122F86C _thrd_wrapper_function+0x36
 8: 0x1123050A CELQPCMM+0xf68 [CELQPCMM:]
Assertion failed: p, file: ../src/rd.h, line: 139, function: rd_calloc
CEE5207E The signal SIGABRT was received.
size = 0./run-test.sh: line 62: 83886261 SIGABRT 

It's failing at size = 0.  z/OS returns null when size is 0 which is different than linux.
I have to add bellow code in rd_malloc, rd_calloc and rd_realloc
if (size == 0)
  size = 1